### PR TITLE
Attempting to update Travis' java version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ notifications:
     on_success: always
     on_failure: always 
     on_start: never 
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install oracle-java8-installer


### PR DESCRIPTION
Travis currently runs on jdk8_31, which causes compiler errors on lambda's using the Class::new construct. This PR attempts to update travis before a build to the latest jdk.