### PR TITLE
Generified HandlerLambda to HandlerLambda<T extends Event>

### DIFF
--- a/backend/src/main/nl/tudelft/ti2806/riverrush/backend/PlayerController.java
+++ b/backend/src/main/nl/tudelft/ti2806/riverrush/backend/PlayerController.java
@@ -11,8 +11,8 @@ public class PlayerController implements Controller {
     private final Player player;
     private final EventDispatcher dispatcher;
     private final Server server;
-    private final HandlerLambda onGameStateChangeLambda = this::onGameStateChange;
-    private final HandlerLambda onJumpLambda = this::onJump;
+    private final HandlerLambda<Event> onGameStateChangeLambda = this::onGameStateChange;
+    private final HandlerLambda<Event> onJumpLambda = this::onJump;
 
 
     public PlayerController(final EventDispatcher dispatcher, final Server server) {

--- a/backend/src/main/nl/tudelft/ti2806/riverrush/network/RenderController.java
+++ b/backend/src/main/nl/tudelft/ti2806/riverrush/network/RenderController.java
@@ -9,7 +9,7 @@ import nl.tudelft.ti2806.riverrush.domain.event.HandlerLambda;
 public class RenderController implements Controller {
     private final Server server;
     private final EventDispatcher dispatcher;
-    private final HandlerLambda onGameStateChangedLambda = this::onGameStateChanged;
+    private final HandlerLambda<Event> onGameStateChangedLambda = this::onGameStateChanged;
 
     public RenderController(EventDispatcher eventDispatcher, Server server) {
         this.dispatcher = eventDispatcher;

--- a/core/src/main/nl/tudelft/ti2806/riverrush/domain/event/BasicEventDispatcher.java
+++ b/core/src/main/nl/tudelft/ti2806/riverrush/domain/event/BasicEventDispatcher.java
@@ -22,7 +22,7 @@ public class BasicEventDispatcher implements EventDispatcher {
 
 
     @Override
-    public <T extends Event> void attach(final Class<T> eventType, final HandlerLambda handler) {
+    public <T extends Event> void attach(final Class<T> eventType, final HandlerLambda<? super T> handler) {
         List<HandlerLambda> handlers = registeredLambdas.get(eventType);
 
         if (handlers == null) {
@@ -34,7 +34,7 @@ public class BasicEventDispatcher implements EventDispatcher {
     }
 
     @Override
-    public <T extends Event> void detach(Class<T> eventType, HandlerLambda handlerLambda) {
+    public <T extends Event> void detach(Class<T> eventType, HandlerLambda<? super T> handlerLambda) {
         List<HandlerLambda> handlers = registeredLambdas.get(eventType);
 
         if (handlers != null) {
@@ -54,11 +54,12 @@ public class BasicEventDispatcher implements EventDispatcher {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void dispatch(final Event event) {
         List<HandlerLambda> handlers = this.registeredLambdas.get(event.getClass());
         if (handlers != null) {
             handlers.forEach(
-                eventListener -> eventListener.handle(event)
+                (f) -> f.handle(event)
             );
         }
     }

--- a/core/src/main/nl/tudelft/ti2806/riverrush/domain/event/EventDispatcher.java
+++ b/core/src/main/nl/tudelft/ti2806/riverrush/domain/event/EventDispatcher.java
@@ -12,9 +12,9 @@ public interface EventDispatcher {
      * @param eventType     - The runtime class to add a listener for.
      * @param handlerLambda - The listener itself.
      */
-    <T extends Event> void attach(Class<T> eventType, HandlerLambda handlerLambda);
+    <T extends Event> void attach(Class<T> eventType, HandlerLambda<? super T> handlerLambda);
 
-    <T extends Event> void detach(Class<T> eventType, HandlerLambda handlerLambda);
+    <T extends Event> void detach(Class<T> eventType, HandlerLambda<? super T> handlerLambda);
 
     /**
      * Mainly used for testing.

--- a/core/src/main/nl/tudelft/ti2806/riverrush/domain/event/HandlerLambda.java
+++ b/core/src/main/nl/tudelft/ti2806/riverrush/domain/event/HandlerLambda.java
@@ -1,6 +1,6 @@
 package nl.tudelft.ti2806.riverrush.domain.event;
 
 @FunctionalInterface
-public interface HandlerLambda {
-    void handle(Event event);
+public interface HandlerLambda<T extends Event> {
+    void handle(T event);
 }

--- a/core/src/test/nl/tudelft/ti2806/riverrush/domain/event/BasicEventDispatcherTest.java
+++ b/core/src/test/nl/tudelft/ti2806/riverrush/domain/event/BasicEventDispatcherTest.java
@@ -24,7 +24,7 @@ public class BasicEventDispatcherTest {
     private EventDispatcher dispatcher;
 
     @Mock
-    private HandlerLambda lambdaMock;
+    private HandlerLambda<Event> lambdaMock;
 
     @Mock
     private Event eventMock;

--- a/desktop/src/main/nl/tudelft/ti2806/riverrush/controller/RenderController.java
+++ b/desktop/src/main/nl/tudelft/ti2806/riverrush/controller/RenderController.java
@@ -8,11 +8,12 @@ import nl.tudelft.ti2806.riverrush.graphics.RiverGame;
 @Singleton
 public class RenderController implements Controller {
     private final EventDispatcher dispatcher;
-    private final HandlerLambda onGameWaitingLambda;
-    private final HandlerLambda onGameAboutToStartLambda;
-    private final HandlerLambda onGameStartedLambda;
-    private final HandlerLambda onAssetsLoadedLambda;
+    private final HandlerLambda<GameWaitingEvent> onGameWaitingLambda;
+    private final HandlerLambda<GameAboutToStartEvent> onGameAboutToStartLambda;
+    private final HandlerLambda<GameStartedEvent> onGameStartedLambda;
+    private final HandlerLambda<AssetsLoadedEvent> onAssetsLoadedLambda;
     private RiverGame game;
+
 
     @Inject
     public RenderController(final RiverGame game, final EventDispatcher eventDispatcher) {


### PR DESCRIPTION
Generified HandlerLambda to HandlerLambda<T extends Event> so that lambda's registered with the EventDispatcher van directly use the runtime event type without having to cast.