### PR TITLE
Require renderer when connecting clients

### DIFF
--- a/core/src/main/nl/tudelft/ti2806/riverrush/network/protocol/BasicProtocol.java
+++ b/core/src/main/nl/tudelft/ti2806/riverrush/network/protocol/BasicProtocol.java
@@ -98,6 +98,7 @@ public final class BasicProtocol implements Protocol {
         EventInstantiator eventInstatiator = this.eventMapping.get(action);
         if (eventInstatiator == null) {
             log.error("Protocol message not registered: " + action);
+            throw new InvalidActionException("Protocol message not registered");
         }
         Event result = eventInstatiator.instantiate();
 


### PR DESCRIPTION
Users can now connect only after the renderer has connected to the game